### PR TITLE
Log Forging vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/db/CmsDriverManager.java
+++ b/src/org/opencms/db/CmsDriverManager.java
@@ -8756,7 +8756,7 @@ public final class CmsDriverManager implements I_CmsEventListener {
                     "Trying to remove user from role that they are not a member of (user: "
                         + username
                         + ", group: "
-                        + groupname
+                        + String.valueOf(groupname).replace("\n", "").replace("\r", "")
                         + ")");
                 skipRemove = true;
             } else {


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Log Forging** issue reported by **Fortify**.

## Issue description
Log Forging allows attackers to manipulate log files by injecting malicious content. This can be used to obfuscate attack traces or forge log entries to conceal unauthorized activities.
 
## Fix instructions
Implement proper input sanitization to remove new lines for values going to the log.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/68b58b64-9153-4d85-8ced-7ffbce20018b/project/7d807077-1ca1-4917-869f-03a35bc7d2dd/report/ebd28e59-2823-4e0c-90e0-58d863c194b4/fix/1e44a809-acd0-4de6-a9ba-3c01efd9fce5)
