### PR TITLE
XXE vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/file/types/CmsResourceTypeImage.java
+++ b/src/org/opencms/file/types/CmsResourceTypeImage.java
@@ -72,6 +72,7 @@ import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.exif.ExifDirectoryBase;
 import com.drew.metadata.exif.ExifIFD0Directory;
+import org.xml.sax.SAXException;
 
 /**
  * Resource type descriptor for the type "image".<p>
@@ -751,6 +752,14 @@ public class CmsResourceTypeImage extends A_CmsResourceType {
             double w = -1, h = -1;
             SAXReader reader = new SAXReader();
             reader.setEntityResolver(new CmsXmlEntityResolver(null));
+            try {
+                reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            }
+            catch(SAXException e) {
+                throw new RuntimeException(e);
+            }
             Document doc = reader.read(new ByteArrayInputStream(content));
             Element node = (Element)(doc.selectSingleNode("/svg"));
             if (node != null) {


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **XXE** issue reported by **Checkmarx**.

## Issue description
XML External Entity (XXE) allows attackers to exploit vulnerable XML processors by including external entities, leading to disclosure of confidential data, denial of service, or server-side request forgery.
 
## Fix instructions
Disable external entity processing in XML parsers or update to versions that mitigate XXE vulnerabilities. Input validation should be implemented to ensure that XML input does not contain external entity references.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/68b58b64-9153-4d85-8ced-7ffbce20018b/project/78e15695-e834-4e4c-9355-cde90b9410fd/report/fdd807e6-a5b8-47a1-bcea-b93fa4be8677/fix/56483793-8144-48fd-a2e1-a65fa8c17232)
