### PR TITLE
Path Traversal vulnerability fix (powered by Mobb)

### DIFF
--- a/src/org/opencms/synchronize/CmsSynchronize.java
+++ b/src/org/opencms/synchronize/CmsSynchronize.java
@@ -496,7 +496,30 @@ public class CmsSynchronize {
 
         String path = m_destinationPathInRfs + res.substring(0, res.lastIndexOf("/"));
         String fileName = res.substring(res.lastIndexOf("/") + 1);
+        ensurePathIsRelativeToDest(path, fileName);
         return new File(path, fileName);
+    }
+
+    private static void ensurePathIsRelativeToDest(File dest, String path) {
+        File file = new File(dest, path);
+        String destCanonicalPath;
+        String fileCanonicalPath;
+    
+        try {
+            destCanonicalPath = dest.getCanonicalPath();
+            fileCanonicalPath = file.getCanonicalPath();
+        } catch (IOException e) {
+            throw new RuntimeException("Potential directory traversal attempt", e);
+        }
+    
+        if (!fileCanonicalPath.startsWith(destCanonicalPath + File.separator)) {
+            throw new RuntimeException("Potential directory traversal attempt");
+        }
+    }
+
+
+    private static void ensurePathIsRelativeToDest(String dest, String path) {
+        ensurePathIsRelativeToDest(new File(dest), path);
     }
 
     /**


### PR DESCRIPTION
This change fixes a **critical severity** (🚨) **Path Traversal** issue reported by **Fortify**.

## Issue description
Path Traversal AKA Directory Traversal occurs when a path coming from user input is not properly sanitized, allowing an attacker to navigate through directories beyond the intended scope. Attackers can exploit this to access sensitive files or execute arbitrary code.
 
## Fix instructions
Sanitize user-supplied paths, ensuring that they are restricted to a predefined directory structure.



[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/68b58b64-9153-4d85-8ced-7ffbce20018b/project/6d1a087f-c777-40d2-9411-aff61775d032/report/76129570-adcf-43a3-b6a1-160a69781504/fix/157d7bce-2e56-4880-b8bb-56bcc43d51a5)